### PR TITLE
Added raw flag for lookup command to maintain backward compatibility with watson

### DIFF
--- a/src/main/java/me/botsko/prism/commandlibs/Flag.java
+++ b/src/main/java/me/botsko/prism/commandlibs/Flag.java
@@ -11,7 +11,8 @@ public enum Flag {
             "Disables grouping of related actions."), OVERWRITE(
             "Forces rb/rs to not skip blocks if something unexpected is at location."), SHARE(
             "-share=player1[,player2...]", "Share a lookup result with another player."), PASTE(
-            "Share your results with a pastebin service and return the link");
+            "Share your results with a pastebin service and return the link"), RAW(
+            "Output raw message instead of formatted JSON");
 
     private final String description;
     private final String permission;

--- a/src/main/java/me/botsko/prism/commands/LookupCommand.java
+++ b/src/main/java/me/botsko/prism/commands/LookupCommand.java
@@ -110,7 +110,7 @@ public class LookupCommand implements SubHandler {
                                     am.showExtended();
                                 }
                                 am.setResultIndex( result_count );
-                                if (sender instanceof Player) {
+                                if (sender instanceof Player && !parameters.hasFlag( Flag.RAW ) ) {
                                     ((Player) sender).spigot().sendMessage(am.getJSONMessage());
                                 } else {
                                     sender.sendMessage(am.getMessage());


### PR DESCRIPTION
We use a minecraft client mod called watson to visualize Prism changes. The recent JSON formatting updates broke the regular expression used to parse the Prism lookup (expects to end with a:&lt;action>):
https://github.com/totemo/watson/blob/master/src/watson/analysis/PrismPatterns.java

This change adds a new -raw flag that uses the old getMessage() instead of getJsonMessage() for player output. I had a look at the watson code to update on their end instead and parsing the json to extract a:&lt;action> would require more work than adding a simple flag to the Prism plugin itself.