### PR TITLE
Custom Block Action

### DIFF
--- a/src/main/java/me/botsko/prism/events/PrismCustomBlockEvent.java
+++ b/src/main/java/me/botsko/prism/events/PrismCustomBlockEvent.java
@@ -1,0 +1,84 @@
+package me.botsko.prism.events;
+
+import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.Plugin;
+
+public class PrismCustomBlockEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final String plugin_name;
+    private final String action_type_name;
+    private final Player player;
+    private final Block block;
+    private final String message;
+
+    /**
+     * @param plugin
+     * @param action_type_name
+     * @param player
+     * @param message
+     */
+    public PrismCustomBlockEvent(Plugin plugin, String action_type_name, Player player, Block block, String message) {
+        this.plugin_name = plugin.getName();
+        this.action_type_name = action_type_name;
+        this.player = player;
+        this.block = block;
+        this.message = message + ChatColor.GOLD + " [" + this.plugin_name + "]" + ChatColor.DARK_AQUA;
+    }
+
+    /**
+     * @return
+     */
+    public String getPluginName() {
+        return plugin_name;
+    }
+
+    /**
+     * @return
+     */
+    public String getActionTypeName() {
+        return action_type_name;
+    }
+
+    /**
+     * @return the player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * @return the message
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * @return the block
+     */
+    public Block getBlock() {
+        return block;
+    }
+
+    /**
+     * Required by bukkit for proper event handling.
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * Required by bukkit for proper event handling.
+     *
+     * @return
+     */
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/me/botsko/prism/listeners/PrismCustomEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismCustomEvents.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionFactory;
 import me.botsko.prism.actionlibs.RecordingQueue;
+import me.botsko.prism.events.PrismCustomBlockEvent;
 import me.botsko.prism.events.PrismCustomPlayerActionEvent;
 
 import org.bukkit.event.EventHandler;
@@ -38,6 +39,20 @@ public class PrismCustomEvents implements Listener {
         if( allowedPlugins.contains( event.getPluginName() ) ) {
             RecordingQueue.addToQueue( ActionFactory.createPlayer(event.getActionTypeName(), event.getPlayer(),
                     event.getMessage()) );
+        }
+    }
+
+    /**
+     * @param event
+     */
+    @SuppressWarnings("unchecked")
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCustomBlockAction(final PrismCustomBlockEvent event) {
+        final ArrayList<String> allowedPlugins = (ArrayList<String>) plugin.getConfig().getList(
+                "prism.tracking.api.allowed-plugins");
+        if (allowedPlugins.contains(event.getPluginName())) {
+            RecordingQueue.addToQueue(ActionFactory.createBlock(event.getActionTypeName(), event.getBlock(),
+                    event.getPlayer().getName()));
         }
     }
 }


### PR DESCRIPTION
This adds the ability to call a custom block action from your own Plugin: `new PrismCustomBlockEvent(plugin, "custom-block-action", player, block, null);`

The best example of this is door-locking which I do on my plugin. This adds the ability for users to lookup and see a door, etc that was locked or unlocked.

There are a couple of unresolved issues here though, namely that calling it for some reason just returns "something"

![image](https://user-images.githubusercontent.com/399721/28501656-f559095e-6fa5-11e7-850a-be2723c96827.png)
